### PR TITLE
JNG-5368 add access instance helper methods

### DIFF
--- a/judo-ui-typescript-rest-axios/src/main/resources/data-axios/accessServiceImpl.ts.hbs
+++ b/judo-ui-typescript-rest-axios/src/main/resources/data-axios/accessServiceImpl.ts.hbs
@@ -2,9 +2,9 @@
 
 import type { AxiosResponse } from 'axios';
 import type { JudoDownloadFile, JudoMetaData, JudoToken } from '../data-api/common';
+import type { AccessService } from '../data-service';
 import { JudoAxiosService } from './JudoAxiosService';
-{{# if application.principal }}import type { {{ classDataName application.principal "Stored" }} } from '../data-api';{{/ if }}
-import { AccessService } from '../data-service';
+import { {{ accessJoinedImportTokens application }} } from '../data-api';
 
 export class AccessServiceImpl extends JudoAxiosService implements AccessService {
 {{# if application.principal }}
@@ -69,4 +69,28 @@ export class AccessServiceImpl extends JudoAxiosService implements AccessService
     });
     return response;
   }
+  {{# each (getAccessRelationsTypes application) as |relation| }}
+  {{# if relation.isListable }}
+  {{# if relation.isCollection }}
+  /**
+   * @return {Promise<{{ classDataName relation.target "Stored" }} | undefined>}
+   */
+  async findInstanceOf{{ firstToUpper relation.name }}(identifier: string): Promise<{{ classDataName relation.target "Stored" }} | undefined> {
+    try {
+      const path = '{{ restPath (getRelationOwnerAsClassType relation) "/"  relation.name "/~list" }}';
+      const response = await this.axios.post(this.getPathForActor(path), {
+        _identifier: identifier,
+      });
+
+      if (Array.isArray(response.data) && response.data.length === 1) {
+        return response.data[0];
+      }
+      return undefined;
+    } catch(error) {
+      return undefined;
+    }
+  }
+  {{/ if }}
+  {{/ if }}
+  {{/ each }}
 }

--- a/judo-ui-typescript-rest-axios/src/main/resources/data-axios/accessServiceImpl.ts.hbs
+++ b/judo-ui-typescript-rest-axios/src/main/resources/data-axios/accessServiceImpl.ts.hbs
@@ -75,13 +75,16 @@ export class AccessServiceImpl extends JudoAxiosService implements AccessService
   /**
    * @return {Promise<{{ classDataName relation.target "Stored" }} | undefined>}
    */
-  async findInstanceOf{{ firstToUpper relation.name }}(identifier: string): Promise<{{ classDataName relation.target "Stored" }} | undefined> {
+  async findInstanceOf{{ firstToUpper relation.name }}(identifier: string, mask?: string): Promise<{{ classDataName relation.target "Stored" }} | undefined> {
     try {
       const path = '{{ restPath (getRelationOwnerAsClassType relation) "/"  relation.name "/~list" }}';
       const response = await this.axios.post(this.getPathForActor(path), {
         _identifier: identifier,
+        _mask: mask,
+        _seek: {
+          limit: 1,
+        },
       });
-
       if (Array.isArray(response.data) && response.data.length === 1) {
         return response.data[0];
       }

--- a/judo-ui-typescript-rest-service/src/main/java/hu/blackbelt/judo/ui/generator/typescript/rest/service/UiServiceHelper.java
+++ b/judo-ui-typescript-rest-service/src/main/java/hu/blackbelt/judo/ui/generator/typescript/rest/service/UiServiceHelper.java
@@ -36,18 +36,30 @@ import static hu.blackbelt.judo.ui.generator.typescript.rest.commons.UiCommonsHe
 @TemplateHelper
 public class UiServiceHelper extends StaticMethodValueResolver {
 
-    public static Collection<RelationType> getNotAccessRelationsTypes(Application application) {
+    public static List<RelationType> getNotAccessRelationsTypes(Application application) {
         return (List<RelationType>) application.getRelationTypes().stream()
                 .filter(r -> !((RelationType) r).isIsAccess())
                 .sorted(Comparator.comparing(NamedElement::getFQName))
-                .collect(Collectors.toList());
+                .toList();
     }
 
-    public static Collection<RelationType> getAccessRelationsTypes(Application application) {
+    public static List<RelationType> getAccessRelationsTypes(Application application) {
         return (List<RelationType>) application.getRelationTypes().stream()
                 .filter(r -> ((RelationType) r).isIsAccess())
                 .sorted(Comparator.comparing(NamedElement::getFQName))
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    public static String accessJoinedImportTokens(Application application) {
+        HashSet<String> tokens = new HashSet<>();
+        if (application.getPrincipal() != null) {
+            tokens.add(classDataName(application.getPrincipal(), "Stored"));
+        }
+        List<RelationType> relations = getAccessRelationsTypes(application);
+        relations.forEach(relation -> {
+            tokens.add(classDataName(relation.getTarget(), "Stored"));
+        });
+        return String.join(", ", tokens);
     }
 
     public static String joinedTokensForApiImport(RelationType relation){

--- a/judo-ui-typescript-rest-service/src/main/java/hu/blackbelt/judo/ui/generator/typescript/rest/service/UiServiceHelper.java
+++ b/judo-ui-typescript-rest-service/src/main/java/hu/blackbelt/judo/ui/generator/typescript/rest/service/UiServiceHelper.java
@@ -51,19 +51,17 @@ public class UiServiceHelper extends StaticMethodValueResolver {
     }
 
     public static String accessJoinedImportTokens(Application application) {
-        HashSet<String> tokens = new HashSet<>();
+        HashSet<String> tokens = new LinkedHashSet<>();
         if (application.getPrincipal() != null) {
             tokens.add(classDataName(application.getPrincipal(), "Stored"));
         }
-        List<RelationType> relations = getAccessRelationsTypes(application);
-        relations.forEach(relation -> {
-            tokens.add(classDataName(relation.getTarget(), "Stored"));
-        });
+        getAccessRelationsTypes(application)
+                .forEach(relation -> tokens.add(classDataName(relation.getTarget(), "Stored")));
         return String.join(", ", tokens);
     }
 
     public static String joinedTokensForApiImport(RelationType relation){
-        HashSet<String> tokens = new HashSet<>();
+        HashSet<String> tokens = new LinkedHashSet<>();
 
         if (!relation.isIsAccess()) {
             tokens.add(classDataName((ClassType) relation.getOwner(), ""));
@@ -105,7 +103,7 @@ public class UiServiceHelper extends StaticMethodValueResolver {
     }
 
     public static String joinedTokensForApiImportForAccessRelationServiceImpl(RelationType relation){
-        HashSet<String> tokens = new HashSet<>();
+        HashSet<String> tokens = new LinkedHashSet<>();
 
         if (!relation.isIsAccess()) {
             tokens.add(classDataName((ClassType) relation.getOwner(), ""));
@@ -124,7 +122,7 @@ public class UiServiceHelper extends StaticMethodValueResolver {
     }
 
     public static String joinedTokensForApiImportClassService(ClassType classType){
-        HashSet<String> tokens = new HashSet<>();
+        HashSet<String> tokens = new LinkedHashSet<>();
 
         tokens.add(classDataName(classType, ""));
         tokens.add(classDataName(classType, "Stored"));

--- a/judo-ui-typescript-rest-service/src/main/resources/data-service/accessService.ts.hbs
+++ b/judo-ui-typescript-rest-service/src/main/resources/data-service/accessService.ts.hbs
@@ -1,16 +1,24 @@
 {{> fragment.header.hbs }}
 
 import type { JudoDownloadFile, JudoMetaData } from '../data-api/common';
-{{# if application.principal }}import { {{ classDataName application.principal "Stored" }} } from '../data-api';{{/ if }}
+import { {{ accessJoinedImportTokens application }} } from '../data-api';
 
 export interface AccessService {
-{{# if application.principal }}
+  {{# if application.principal }}
   getPrincipal(): Promise<{{ classDataName application.principal "Stored" }}>;
-{{/if}}
+  {{/ if }}
 
   getMetaData(): Promise<JudoMetaData>;
 
   uploadFile(attributePath: string, file: File): Promise<string>;
 
   downloadFile(downloadToken: string, disposition: 'inline' | 'attachment'): Promise<any>;
+
+  {{# each (getAccessRelationsTypes application) as |relation| }}
+  {{# if relation.isListable }}
+  {{# if relation.isCollection }}
+  findInstanceOf{{ firstToUpper relation.name }}(identifier: string): Promise<{{ classDataName relation.target "Stored" }} | undefined>;
+  {{/ if }}
+  {{/ if }}
+  {{/ each }}
 }

--- a/judo-ui-typescript-rest-service/src/main/resources/data-service/accessService.ts.hbs
+++ b/judo-ui-typescript-rest-service/src/main/resources/data-service/accessService.ts.hbs
@@ -17,7 +17,7 @@ export interface AccessService {
   {{# each (getAccessRelationsTypes application) as |relation| }}
   {{# if relation.isListable }}
   {{# if relation.isCollection }}
-  findInstanceOf{{ firstToUpper relation.name }}(identifier: string): Promise<{{ classDataName relation.target "Stored" }} | undefined>;
+  findInstanceOf{{ firstToUpper relation.name }}(identifier: string, mask?: string): Promise<{{ classDataName relation.target "Stored" }} | undefined>;
   {{/ if }}
   {{/ if }}
   {{/ each }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5368" title="JNG-5368" target="_blank"><img alt="Task" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />JNG-5368</a>  Util for querying instance from access by identifier
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

```typescript
import { ViewCreatureStored, ViewGalaxyStored, ViewMatterStored, ViewPlanetStored } from '../data-api';
import type { JudoDownloadFile, JudoMetaData } from '../data-api/common';

export interface AccessService {
  getMetaData(): Promise<JudoMetaData>;

  uploadFile(attributePath: string, file: File): Promise<string>;

  downloadFile(downloadToken: string, disposition: 'inline' | 'attachment'): Promise<any>;

  findInstanceOfCreatures(identifier: string, mask?: string): Promise<ViewCreatureStored | undefined>;
  findInstanceOfGalaxies(identifier: string, mask?: string): Promise<ViewGalaxyStored | undefined>;
  findInstanceOfMatter(identifier: string, mask?: string): Promise<ViewMatterStored | undefined>;
}
```